### PR TITLE
Added missing url parameter in .desktop

### DIFF
--- a/appimage.sh
+++ b/appimage.sh
@@ -177,7 +177,7 @@ process_appimage() {
             sub(/^[^ ]+/, "", parts[2])  # Remove the first word (original command)
             print "Exec=" home "/.local/share/AppImage/" app_name ".AppImage" parts[2]
         } else {
-            print "Exec=" home "/.local/share/AppImage/" app_name ".AppImage"
+            print "Exec=" home "/.local/share/AppImage/" app_name ".AppImage %u"
         }
         next
     }


### PR DESCRIPTION
The script accidentally removes the `%u` in the main `Exec` part of the .desktop file.
Without this, the AppImage installed Zen Browser cannot be used as the default browser in GNOME - and possibly run into problems when trying to open links.