### PR TITLE
fix: address tarball compression change to `xz`

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -4,8 +4,8 @@ app_name=zen
 literal_name_of_installation_directory=".tarball-installations"
 universal_path_for_installation_directory="$HOME/$literal_name_of_installation_directory"
 app_installation_directory="$universal_path_for_installation_directory/zen"
-official_package_location="https://github.com/zen-browser/desktop/releases/latest/download/zen.linux-x86_64.tar.bz2"
-tar_location=$(mktemp /tmp/zen.XXXXXX.tar.bz2)
+official_package_location="https://github.com/zen-browser/desktop/releases/latest/download/zen.linux-x86_64.tar.xz"
+tar_location=$(mktemp /tmp/zen.XXXXXX.tar.xz)
 open_tar_application_data_location="zen"
 local_bin_path="$HOME/.local/bin"
 local_application_path="$HOME/.local/share/applications"
@@ -43,7 +43,7 @@ else
     exit
 fi
 
-tar -xvjf $tar_location
+tar -xvJf $tar_location
 
 echo "Installed and untarred successfully"
 

--- a/install.sh
+++ b/install.sh
@@ -1,5 +1,7 @@
 #!/bin/bash
 
+set -euo pipefail
+
 app_name=zen
 literal_name_of_installation_directory=".tarball-installations"
 universal_path_for_installation_directory="$HOME/$literal_name_of_installation_directory"


### PR DESCRIPTION
### Summary
This PR updates the installation script to handle the change in the tarball extension from `.tar.bz2` to `.tar.xz`. The script previously failed, since the change in the compression format.

### Changes
- [x] Adjusted the file extension in the script to match the `.tar.xz` format.
- [x] Updated the unpacking command
- [x] Immediate exit on error in pipeline of any command