### PR TITLE
`fix`: remove old files only on successful download

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -20,6 +20,20 @@ echo "Welcome to Zen tarball installer, just chill and wait for the installation
 
 sleep 1
 
+echo "Downloading the latest package"
+curl -L -o $tar_location $official_package_location
+if [ $? -eq 0 ]; then
+    echo OK
+else
+    echo "Download failed. Curl not found or not installed"
+    exit
+fi
+
+echo "Extracting Zen Browser..."
+tar -xvJf $tar_location
+
+echo "Untarred successfully!"
+
 echo "Checking to see if an older installation exists"
 if [ -f "$app_bin_in_local_bin" ]; then
   echo "Old bin file detected, removing..."
@@ -35,19 +49,6 @@ if [ -f "$desktop_in_local_applications" ]; then
   echo "Old app files are found, removing..."
   rm "$desktop_in_local_applications"
 fi
-
-echo "Installing the latest package"
-curl -L -o $tar_location $official_package_location
-if [ $? -eq 0 ]; then
-    echo OK
-else
-    echo "Installation failed. Curl not found or not installed"
-    exit
-fi
-
-tar -xvJf $tar_location
-
-echo "Installed and untarred successfully"
 
 if [ ! -d $universal_path_for_installation_directory ]; then
   echo "Creating the $universal_path_for_installation_directory directory for installation"


### PR DESCRIPTION
### Summary
Earlier, the script would first remove old files, then attempt to download the latest version. However, if for whatever reason the download or the tarball extraction fails, the script would've already removed old files by that point, which it shouldn't have. This issue was particularly noted with the recent change in the tarball compression format (#16) where the script would fail, but would've removed old files anyway.

### Changes
- [x] Attempt to download and extract Zen, before removing old files.