### PR TITLE
`feat`: install zen as root binary and integrate with 1password desktop app

### DIFF
--- a/1password-integration.sh
+++ b/1password-integration.sh
@@ -1,0 +1,70 @@
+#!/bin/bash
+
+config_directory="/etc/1password"
+allowed_browsers_file="$config_directory/custom_allowed_browsers"
+config_backup_directory="/tmp/1password_config_backup_$(date +'%Y%m%d_%H%M%S')"
+directory_created=false
+
+# Rollback
+rollback() {
+    echo "Rolling back changes..."
+
+    if [ "$directory_created" = true ];then
+        sudo rm -rf "$config_directory"
+    elif [ -d "$config_backup_directory" ]; then
+        echo "Restoring backup of 1Password config directory at \"$config_directory\" from \"$config_backup_directory\""
+        sudo rm -rf "$config_directory"
+        sudo mv "$config_backup_directory" "$config_directory"
+        echo "Rollback complete..."
+    else
+        echo "Nothing to rollback! Exiting..."
+    fi
+
+    exit 1
+}
+
+# Backup
+if [ -d "$config_directory" ]; then
+    echo "Backing up \"$config_directory\" to \"$config_backup_directory\"..."
+    sudo cp -r "$config_directory" "$config_backup_directory"
+    if [ $? -ne 0 ]; then
+        echo "Failed to backup \"$config_directory\". Exiting..."
+        exit 1
+    fi
+fi
+
+# Check directory
+if [ ! -d "$config_directory" ]; then
+    sudo mkdir -p "$config_directory"
+    if [ $? -ne 0 ]; then
+        echo "Failed to create config directory at \"$config_directory\"."
+        rollback
+    fi
+    directory_created=true
+else
+    echo "1Password Config directory already exists!"
+fi
+
+# Check file
+if [ ! -f "$allowed_browsers_file" ]; then
+    echo "zen" | sudo tee -a "$allowed_browsers_file" > /dev/null
+    if [ $? -ne 0 ]; then
+        echo "Failed to append to the custom allowed browsers file at \"$allowed_browsers_file\"."
+        rollback
+    fi
+else
+    echo "Custom Allowed Browsers file already exists!"
+    
+    # Check if Zen is already whitelisted or not
+    if ! grep -Fxq "zen" "$allowed_browsers_file"; then
+        echo "zen" | sudo tee -a "$allowed_browsers_file" > /dev/null
+        if [ $? -ne 0 ]; then
+            echo "Failed to append to the custom allowed browsers file at \"$allowed_browsers_file\"."
+            rollback
+        fi
+    else
+        echo "Zen is already set as whitelisted in the custom allowed browsers file"
+    fi
+fi
+
+echo "1Password integration with Zen Browser was successful! Have fun! 🐷"

--- a/1password-integration.sh
+++ b/1password-integration.sh
@@ -26,6 +26,13 @@ rollback() {
     exit 1
 }
 
+# Check OS
+if [[ "$(uname)" != "Linux" ]]; then
+    echo "This script is only for Linux."
+    echo "Visit https://docs.zen-browser.app/guides/1password to learn more"
+    exit 1
+fi
+
 SUDO=
 if [ "$(id -u)" -ne 0 ]; then
     if ! available sudo; then

--- a/1password-integration.sh
+++ b/1password-integration.sh
@@ -2,19 +2,19 @@
 
 config_directory="/etc/1password"
 allowed_browsers_file="$config_directory/custom_allowed_browsers"
-config_backup_directory="/tmp/1password_config_backup_$(date +'%Y%m%d_%H%M%S')"
+config_backup_directory=""
 directory_created=false
 
 # Rollback
 rollback() {
     echo "Rolling back changes..."
 
-    if [ "$directory_created" = true ];then
-        sudo rm -rf "$config_directory"
-    elif [ -d "$config_backup_directory" ]; then
+    if [ "$directory_created" = true ]; then
+        sudo rm -rv "$config_directory"
+    elif [ -n "$config_backup_directory" ] && [ -d "$config_backup_directory" ]; then
         echo "Restoring backup of 1Password config directory at \"$config_directory\" from \"$config_backup_directory\""
-        sudo rm -rf "$config_directory"
-        sudo mv "$config_backup_directory" "$config_directory"
+        sudo rm -rv "$config_directory"
+        sudo mv -v "$config_backup_directory" "$config_directory"
         echo "Rollback complete..."
     else
         echo "Nothing to rollback! Exiting..."
@@ -25,8 +25,10 @@ rollback() {
 
 # Backup
 if [ -d "$config_directory" ]; then
+    config_backup_directory=$(mktemp -d /tmp/1password_config_backup_XXXXXX)
     echo "Backing up \"$config_directory\" to \"$config_backup_directory\"..."
-    sudo cp -r "$config_directory" "$config_backup_directory"
+    sudo cp -r "$config_directory/." "$config_backup_directory"
+    echo -e "\nNOTE: You can restore your previous 1Password configuration from $config_backup_directory, till your /tmp directory is cleared (usually at the next boot)"
     if [ $? -ne 0 ]; then
         echo "Failed to backup \"$config_directory\". Exiting..."
         exit 1
@@ -35,7 +37,7 @@ fi
 
 # Check directory
 if [ ! -d "$config_directory" ]; then
-    sudo mkdir -p "$config_directory"
+    sudo mkdir -pv "$config_directory"
     if [ $? -ne 0 ]; then
         echo "Failed to create config directory at \"$config_directory\"."
         rollback
@@ -64,6 +66,7 @@ else
         fi
     else
         echo "Zen is already set as whitelisted in the custom allowed browsers file"
+        exit 0
     fi
 fi
 

--- a/1password-integration.sh
+++ b/1password-integration.sh
@@ -1,5 +1,6 @@
 #!/bin/bash
 
+binary_name="zen"
 config_directory="/etc/1password"
 allowed_browsers_file="$config_directory/custom_allowed_browsers"
 config_backup_directory=""
@@ -23,12 +24,16 @@ rollback() {
     exit 1
 }
 
+echo -e "Welcome, just chill and we'll configure the rest for you!\n"
+
+sleep 1
+
 # Backup
 if [ -d "$config_directory" ]; then
     config_backup_directory=$(mktemp -d /tmp/1password_config_backup_XXXXXX)
     echo "Backing up \"$config_directory\" to \"$config_backup_directory\"..."
     sudo cp -r "$config_directory/." "$config_backup_directory"
-    echo -e "\nNOTE: You can restore your previous 1Password configuration from $config_backup_directory, till your /tmp directory is cleared (usually at the next boot)"
+    echo -e "\nNOTE: You can restore your previous 1Password configuration from \"$config_backup_directory\", till your /tmp directory is cleared (usually at the next boot)"
     if [ $? -ne 0 ]; then
         echo "Failed to backup \"$config_directory\". Exiting..."
         exit 1
@@ -37,10 +42,12 @@ fi
 
 # Check directory
 if [ ! -d "$config_directory" ]; then
-    sudo mkdir -pv "$config_directory"
+    sudo mkdir -p "$config_directory"
     if [ $? -ne 0 ]; then
         echo "Failed to create config directory at \"$config_directory\"."
         rollback
+    else
+        echo "Created config directory at \"$config_directory\""
     fi
     directory_created=true
 else
@@ -49,7 +56,8 @@ fi
 
 # Check file
 if [ ! -f "$allowed_browsers_file" ]; then
-    echo "zen" | sudo tee -a "$allowed_browsers_file" > /dev/null
+    echo "Creating 1Password Custom Allowed Browsers file and adding Zen to it..."
+    echo "$binary_name" | sudo tee -a "$allowed_browsers_file" > /dev/null
     if [ $? -ne 0 ]; then
         echo "Failed to append to the custom allowed browsers file at \"$allowed_browsers_file\"."
         rollback
@@ -58,14 +66,15 @@ else
     echo "Custom Allowed Browsers file already exists!"
     
     # Check if Zen is already whitelisted or not
-    if ! grep -Fxq "zen" "$allowed_browsers_file"; then
-        echo "zen" | sudo tee -a "$allowed_browsers_file" > /dev/null
+    if ! grep -Fxq "$binary_name" "$allowed_browsers_file"; then
+        echo "Adding Zen to 1Password Custom Allowed Browsers file..."
+        echo "$binary_name" | sudo tee -a "$allowed_browsers_file" > /dev/null
         if [ $? -ne 0 ]; then
             echo "Failed to append to the custom allowed browsers file at \"$allowed_browsers_file\"."
             rollback
         fi
     else
-        echo "Zen is already set as whitelisted in the custom allowed browsers file"
+        echo "Zen is already whitelisted in the custom allowed browsers file"
         exit 0
     fi
 fi

--- a/1password-integration.sh
+++ b/1password-integration.sh
@@ -6,16 +6,18 @@ allowed_browsers_file="$config_directory/custom_allowed_browsers"
 config_backup_directory=""
 directory_created=false
 
+available() { command -v $1 >/dev/null; }
+
 # Rollback
 rollback() {
     echo "Rolling back changes..."
 
     if [ "$directory_created" = true ]; then
-        sudo rm -rv "$config_directory"
+        $SUDO rm -rv "$config_directory"
     elif [ -n "$config_backup_directory" ] && [ -d "$config_backup_directory" ]; then
         echo "Restoring backup of 1Password config directory at \"$config_directory\" from \"$config_backup_directory\""
-        sudo rm -rv "$config_directory"
-        sudo mv -v "$config_backup_directory" "$config_directory"
+        $SUDO rm -rv "$config_directory"
+        $SUDO mv -v "$config_backup_directory" "$config_directory"
         echo "Rollback complete..."
     else
         echo "Nothing to rollback! Exiting..."
@@ -23,6 +25,15 @@ rollback() {
 
     exit 1
 }
+
+SUDO=
+if [ "$(id -u)" -ne 0 ]; then
+    if ! available sudo; then
+        echo "This script requires superuser permissions. Please re-run as root."
+        exit 1
+    fi
+    SUDO="sudo"
+fi
 
 echo -e "Welcome, just chill and we'll configure the rest for you!\n"
 
@@ -32,8 +43,8 @@ sleep 1
 if [ -d "$config_directory" ]; then
     config_backup_directory=$(mktemp -d /tmp/1password_config_backup_XXXXXX)
     echo "Backing up \"$config_directory\" to \"$config_backup_directory\"..."
-    sudo cp -r "$config_directory/." "$config_backup_directory"
-    echo -e "\nNOTE: You can restore your previous 1Password configuration from \"$config_backup_directory\", till your /tmp directory is cleared (usually at the next boot)"
+    $SUDO cp -r "$config_directory/." "$config_backup_directory"
+    echo -e "\nNOTE: You can restore your previous 1Password configuration from \"$config_backup_directory\", anytime before your /tmp directory is cleared (usually at the next boot).\n"
     if [ $? -ne 0 ]; then
         echo "Failed to backup \"$config_directory\". Exiting..."
         exit 1
@@ -42,7 +53,7 @@ fi
 
 # Check directory
 if [ ! -d "$config_directory" ]; then
-    sudo mkdir -p "$config_directory"
+    $SUDO mkdir -p "$config_directory"
     if [ $? -ne 0 ]; then
         echo "Failed to create config directory at \"$config_directory\"."
         rollback
@@ -57,7 +68,7 @@ fi
 # Check file
 if [ ! -f "$allowed_browsers_file" ]; then
     echo "Creating 1Password Custom Allowed Browsers file and adding Zen to it..."
-    echo "$binary_name" | sudo tee -a "$allowed_browsers_file" > /dev/null
+    echo "$binary_name" | $SUDO tee -a "$allowed_browsers_file" > /dev/null
     if [ $? -ne 0 ]; then
         echo "Failed to append to the custom allowed browsers file at \"$allowed_browsers_file\"."
         rollback
@@ -68,13 +79,13 @@ else
     # Check if Zen is already whitelisted or not
     if ! grep -Fxq "$binary_name" "$allowed_browsers_file"; then
         echo "Adding Zen to 1Password Custom Allowed Browsers file..."
-        echo "$binary_name" | sudo tee -a "$allowed_browsers_file" > /dev/null
+        echo "$binary_name" | $SUDO tee -a "$allowed_browsers_file" > /dev/null
         if [ $? -ne 0 ]; then
             echo "Failed to append to the custom allowed browsers file at \"$allowed_browsers_file\"."
             rollback
         fi
     else
-        echo "Zen is already whitelisted in the custom allowed browsers file"
+        echo "Zen was already whitelisted in the custom allowed browsers file. You're all set! 🐷"
         exit 0
     fi
 fi

--- a/install-as-root.sh
+++ b/install-as-root.sh
@@ -17,10 +17,147 @@ desktop_in_local_applications="$root_application_path/$app_name.desktop"
 icon_path="$app_installation_directory/browser/chrome/icons/default/default128.png"
 executable_path=$app_installation_directory/zen
 
+install() {
+  echo "We're installing Zen, just chill and wait for the installation to complete!\n"
+
+  # Set the official package download URL
+  determinePackage "$@"
+
+  echo "Downloading the latest package"
+  curl -L --progress-bar -o $tar_location $official_package_location
+
+  echo "Extracting Zen Browser..."
+  tar -xvJf $tar_location
+
+  echo "Untarred successfully!"
+
+  echo "Checking to see if an older installation exists"
+  remove
+
+  if [ ! -d $universal_path_for_installation_directory ]; then
+    echo "Creating the $universal_path_for_installation_directory directory for installation"
+    mkdir $universal_path_for_installation_directory
+  fi
+
+  mv $open_tar_application_data_location $app_installation_directory
+
+  echo "Zen successfully moved to your safe place!"
+
+  rm $tar_location
+
+  if [ ! -d $root_bin_path ]; then
+    echo "$root_bin_path not found, creating it for you"
+    mkdir $root_bin_path
+  fi
+
+  touch $app_bin_in_root_bin
+  chmod u+x $app_bin_in_root_bin
+  echo "#!/bin/bash
+  $executable_path" >> $app_bin_in_root_bin
+
+  echo "Created executable for your \$PATH if you ever need"
+
+  if [ ! -d $root_application_path ]; then
+    echo "Creating the $root_application_path directory for desktop file"
+    mkdir $root_application_path
+  fi
+
+
+  touch $desktop_in_local_applications
+  echo "
+  [Desktop Entry]
+  Name=Zen Browser
+  Comment=Experience tranquillity while browsing the web without people tracking you!
+  Keywords=web;browser;internet
+  Exec=$executable_path %u
+  Icon=$icon_path
+  Terminal=false
+  StartupNotify=true
+  StartupWMClass=zen
+  NoDisplay=false
+  Type=Application
+  MimeType=text/html;text/xml;application/xhtml+xml;application/vnd.mozilla.xul+xml;text/mml;x-scheme-handler/http;x-scheme-handler/https;
+  Categories=Network;WebBrowser;
+  Actions=new-window;new-private-window;profile-manager-window;
+  [Desktop Action new-window]
+  Name=Open a New Window
+  Exec=$executable_path --new-window %u
+  [Desktop Action new-private-window]
+  Name=Open a New Private Window
+  Exec=$executable_path --private-window %u
+  [Desktop Action profile-manager-window]
+  Name=Open the Profile Manager
+  Exec=$executable_path --ProfileManager
+  " >> $desktop_in_local_applications
+
+  echo "Created desktop entry successfully"
+  echo "Installation is successful"
+  echo "Done, and done, have fun! 🐷"
+
+  exit 0
+}
+
+determinePackage() {
+  case "$os_arch" in
+      x86_64) echo "64-bit (Intel/AMD) architecture identified!" ;;
+      aarch64|arm64)
+      echo "64-bit ARM architecture identified!"
+      os_arch="aarch64" ;;
+      *)
+      echo "Zen doesn't support this architecture: $os_arch"
+      exit 1 ;;
+  esac
+  
+  if [ "${1:-}" == "--twilight" ]; then
+    official_package_location="https://github.com/zen-browser/desktop/releases/download/twilight/zen.linux-$os_arch.tar.xz"
+    echo "You're currently in Twilight mode, this means you're downloading the latest experimental features and updates."
+  else
+    official_package_location="https://github.com/zen-browser/desktop/releases/latest/download/zen.linux-$os_arch.tar.xz"
+  fi
+}
+
+remove() {
+  if [ -f "$app_bin_in_root_bin" ]; then
+    echo "Old bin file detected, removing..."
+    rm "$app_bin_in_root_bin"
+  fi
+
+  if [ -d "$app_installation_directory" ]; then
+    echo "Old app files are found, removing..."
+    rm -rf "$app_installation_directory"
+  fi
+
+  if [ -f "$desktop_in_local_applications" ]; then
+    echo "Old desktop files are found, removing..."
+    rm "$desktop_in_local_applications"
+  fi
+}
+
+uninstall() {
+  read -p "WARN: This will remove Zen Browser from your system. Do you wish to proceed? [y/N]: " confirm
+  if [[ ! "$confirm" =~ ^[Yy]$ ]]; then
+    echo "Nice save! We didn't remove Zen from your system."
+    echo "Exiting..."
+    exit 0
+  fi
+  echo "Uninstalling Zen Browser..."
+  remove
+  echo "Keeping your profile data will let you continue where you left off if you reinstall Zen later."
+  read -p "Do you want to delete your Zen Profiles? This will remove all your bookmarks, history, and settings. [y/N]: " remove_profile
+  if [[ "$remove_profile" =~ ^[Yy]$ ]]; then
+    echo "Removing Zen Profiles data..."
+    rm -rf "$HOME/.zen"
+  else
+    echo "Keeping Zen Profiles data..."
+  fi
+  echo "Zen Browser has been uninstalled."
+  exit 0
+}
+
 # Check OS
 if [[ "$(uname)" != "Linux" ]]; then
     echo "This script is only for Linux."
-    echo "Visit https://github.com/zen-browser/desktop#-installation to learn more about supported operating systems"
+    echo "Visit https://github.com/zen-browser/desktop#-installation to learn more about supported operating systems."
     exit 1
 fi
 
@@ -30,111 +167,30 @@ if [ "$EUID" -ne 0 ]; then
     exit 1
 fi
 
-echo -e "Welcome to Zen tarball installer, just chill and wait for the installation to complete!\n"
+echo -e "Welcome to Zen tarball installer!\n"
 
 sleep 1
 
-case "$os_arch" in
-    x86_64) echo "64-bit (Intel/AMD) architecture identified!" ;;
-    aarch64|arm64)
-		echo "64-bit ARM architecture identified!"
-		os_arch="aarch64" ;;
-    *)
-		echo "Zen doesn't support this architecture: $os_arch"
-		exit 1 ;;
+echo "What would you like to do?"
+echo "1) Install/Update Zen Browser"
+echo "2) Uninstall Zen Browser"
+echo "3) Exit"
+read -rn1 -p "Enter your choice [1/2/3]: " choice
+echo
+
+case $choice in
+  1)
+    install "$@"
+    ;;
+  2)
+    uninstall
+    ;;
+  3)
+    echo "Exiting... Bye! 🐷"
+    exit 0
+    ;;
+  *)
+    echo "Invalid choice. Exiting."
+    exit 1
+    ;;
 esac
-
-# Set the official package download URL
-official_package_location="https://github.com/zen-browser/desktop/releases/latest/download/zen.linux-$os_arch.tar.xz"
-
-echo "Downloading the latest package"
-curl -L --progress-bar -o $tar_location $official_package_location
-if [ $? -eq 0 ]; then
-    echo OK
-else
-    echo "Download failed. Curl not found or not installed"
-    exit
-fi
-
-echo "Extracting Zen Browser..."
-tar -xvJf $tar_location
-
-echo "Untarred successfully!"
-
-echo "Checking to see if an older installation exists"
-if [ -f "$app_bin_in_root_bin" ]; then
-  echo "Old bin file detected, removing..."
-  rm "$app_bin_in_root_bin"
-fi
-
-if [ -d "$app_installation_directory" ]; then
-  echo "Old app files are found, removing..."
-  rm -rf "$app_installation_directory"
-fi
-
-if [ -f "$desktop_in_local_applications" ]; then
-  echo "Old desktop files are found, removing..."
-  rm "$desktop_in_local_applications"
-fi
-
-if [ ! -d $universal_path_for_installation_directory ]; then
-  echo "Creating the $universal_path_for_installation_directory directory for installation"
-  mkdir $universal_path_for_installation_directory
-fi
-
-mv $open_tar_application_data_location $app_installation_directory
-
-echo "Zen successfully moved to your safe place!"
-
-rm $tar_location
-
-if [ ! -d $root_bin_path ]; then
-  echo "$root_bin_path not found, creating it for you"
-  mkdir $root_bin_path
-fi
-
-touch $app_bin_in_root_bin
-chmod u+x $app_bin_in_root_bin
-echo "#!/bin/bash
-$executable_path" >> $app_bin_in_root_bin
-
-echo "Created executable for your \$PATH if you ever need"
-
-if [ ! -d $root_application_path ]; then
-  echo "Creating the $root_application_path directory for desktop file"
-  mkdir $root_application_path
-fi
-
-
-touch $desktop_in_local_applications
-echo "
-[Desktop Entry]
-Name=Zen Browser
-Comment=Experience tranquillity while browsing the web without people tracking you!
-Keywords=web;browser;internet
-Exec=$executable_path %u
-Icon=$icon_path
-Terminal=false
-StartupNotify=true
-StartupWMClass=zen
-NoDisplay=false
-Type=Application
-MimeType=text/html;text/xml;application/xhtml+xml;application/vnd.mozilla.xul+xml;text/mml;x-scheme-handler/http;x-scheme-handler/https;
-Categories=Network;WebBrowser;
-Actions=new-window;new-private-window;profile-manager-window;
-[Desktop Action new-window]
-Name=Open a New Window
-Exec=$executable_path --new-window %u
-[Desktop Action new-private-window]
-Name=Open a New Private Window
-Exec=$executable_path --private-window %u
-[Desktop Action profile-manager-window]
-Name=Open the Profile Manager
-Exec=$executable_path --ProfileManager
-" >> $desktop_in_local_applications
-
-echo "Created desktop entry successfully"
-echo "Installation is successful"
-echo "Done, and done, have fun! 🐷"
-
-exit 0

--- a/install-as-root.sh
+++ b/install-as-root.sh
@@ -1,0 +1,119 @@
+#!/bin/bash
+
+set -euo pipefail
+
+app_name=zen
+literal_name_of_installation_directory="src"
+universal_path_for_installation_directory="/usr/local/$literal_name_of_installation_directory"
+app_installation_directory="$universal_path_for_installation_directory/zen"
+official_package_location="https://github.com/zen-browser/desktop/releases/latest/download/zen.linux-x86_64.tar.xz"
+tar_location=$(mktemp /tmp/zen.XXXXXX.tar.xz)
+open_tar_application_data_location="zen"
+root_bin_path="/usr/bin"
+root_application_path="/usr/share/applications"
+app_bin_in_root_bin="$root_bin_path/$app_name"
+desktop_in_local_applications="$root_application_path/$app_name.desktop"
+icon_path="$app_installation_directory/browser/chrome/icons/default/default128.png"
+executable_path=$app_installation_directory/zen
+
+# Check if the script is being run as root
+if [ "$EUID" -ne 0 ]; then
+    echo "This script requires superuser permissions. Please re-run as root."
+    exit 1
+fi
+
+echo "Welcome to Zen tarball installer, just chill and wait for the installation to complete!"
+
+sleep 1
+
+echo "Downloading the latest package"
+curl -L -o $tar_location $official_package_location
+if [ $? -eq 0 ]; then
+    echo OK
+else
+    echo "Download failed. Curl not found or not installed"
+    exit
+fi
+
+echo "Extracting Zen Browser..."
+tar -xvJf $tar_location
+
+echo "Untarred successfully!"
+
+echo "Checking to see if an older installation exists"
+if [ -f "$app_bin_in_root_bin" ]; then
+  echo "Old bin file detected, removing..."
+  rm "$app_bin_in_root_bin"
+fi
+
+if [ -d "$app_installation_directory" ]; then
+  echo "Old app files are found, removing..."
+  rm -rf "$app_installation_directory"
+fi
+
+if [ -f "$desktop_in_local_applications" ]; then
+  echo "Old desktop files are found, removing..."
+  rm "$desktop_in_local_applications"
+fi
+
+if [ ! -d $universal_path_for_installation_directory ]; then
+  echo "Creating the $universal_path_for_installation_directory directory for installation"
+  mkdir $universal_path_for_installation_directory
+fi
+
+mv $open_tar_application_data_location $app_installation_directory
+
+echo "Zen successfully moved to your safe place!"
+
+rm $tar_location
+
+if [ ! -d $root_bin_path ]; then
+  echo "$root_bin_path not found, creating it for you"
+  mkdir $root_bin_path
+fi
+
+touch $app_bin_in_root_bin
+chmod u+x $app_bin_in_root_bin
+echo "#!/bin/bash
+$executable_path" >> $app_bin_in_root_bin
+
+echo "Created executable for your \$PATH if you ever need"
+
+if [ ! -d $root_application_path ]; then
+  echo "Creating the $root_application_path directory for desktop file"
+  mkdir $root_application_path
+fi
+
+
+touch $desktop_in_local_applications
+echo "
+[Desktop Entry]
+Name=Zen Browser
+Comment=Experience tranquillity while browsing the web without people tracking you!
+Keywords=web;browser;internet
+Exec=$executable_path %u
+Icon=$icon_path
+Terminal=false
+StartupNotify=true
+StartupWMClass=zen
+NoDisplay=false
+Type=Application
+MimeType=text/html;text/xml;application/xhtml+xml;application/vnd.mozilla.xul+xml;text/mml;x-scheme-handler/http;x-scheme-handler/https;
+Categories=Network;WebBrowser;
+Actions=new-window;new-private-window;profile-manager-window;
+[Desktop Action new-window]
+Name=Open a New Window
+Exec=$executable_path --new-window %u
+[Desktop Action new-private-window]
+Name=Open a New Private Window
+Exec=$executable_path --private-window %u
+[Desktop Action profile-manager-window]
+Name=Open the Profile Manager
+Exec=$executable_path --ProfileManager
+" >> $desktop_in_local_applications
+
+echo "Created desktop entry successfully"
+echo "Installation is successful"
+echo "Done, and done, have fun! 🐷"
+
+exit 0

--- a/install-as-root.sh
+++ b/install-as-root.sh
@@ -29,7 +29,9 @@ sleep 1
 
 case "$os_arch" in
     x86_64) echo "64-bit (Intel/AMD) architecture identified!" ;;
-    aarch64|arm64) echo "64-bit ARM architecture identified!" ;;
+    aarch64|arm64)
+		echo "64-bit ARM architecture identified!"
+		official_package_location="https://github.com/zen-browser/desktop/releases/latest/download/zen.linux-aarch64.tar.xz" ;;
     *)
 		echo "Zen doesn't support this architecture: $os_arch"
 		exit 1 ;;

--- a/install-as-root.sh
+++ b/install-as-root.sh
@@ -2,11 +2,12 @@
 
 set -euo pipefail
 
+os_arch=$(uname -m)
 app_name=zen
 literal_name_of_installation_directory="src"
 universal_path_for_installation_directory="/usr/local/$literal_name_of_installation_directory"
 app_installation_directory="$universal_path_for_installation_directory/zen"
-official_package_location="https://github.com/zen-browser/desktop/releases/latest/download/zen.linux-x86_64.tar.xz"
+official_package_location="https://github.com/zen-browser/desktop/releases/latest/download/zen.linux-$os_arch.tar.xz"
 tar_location=$(mktemp /tmp/zen.XXXXXX.tar.xz)
 open_tar_application_data_location="zen"
 root_bin_path="/usr/bin"
@@ -22,12 +23,20 @@ if [ "$EUID" -ne 0 ]; then
     exit 1
 fi
 
-echo "Welcome to Zen tarball installer, just chill and wait for the installation to complete!"
+echo -e "Welcome to Zen tarball installer, just chill and wait for the installation to complete!\n"
 
 sleep 1
 
+case "$os_arch" in
+    x86_64) echo "64-bit (Intel/AMD) architecture identified!" ;;
+    aarch64|arm64) echo "64-bit ARM architecture identified!" ;;
+    *)
+		echo "Zen doesn't support this architecture: $os_arch"
+		exit 1 ;;
+esac
+
 echo "Downloading the latest package"
-curl -L -o $tar_location $official_package_location
+curl -L --progress-bar -o $tar_location $official_package_location
 if [ $? -eq 0 ]; then
     echo OK
 else

--- a/install-as-root.sh
+++ b/install-as-root.sh
@@ -7,7 +7,7 @@ app_name=zen
 literal_name_of_installation_directory="src"
 universal_path_for_installation_directory="/usr/local/$literal_name_of_installation_directory"
 app_installation_directory="$universal_path_for_installation_directory/zen"
-official_package_location="https://github.com/zen-browser/desktop/releases/latest/download/zen.linux-$os_arch.tar.xz"
+official_package_location="" # Placeholder for download URL, to be set later
 tar_location=$(mktemp /tmp/zen.XXXXXX.tar.xz)
 open_tar_application_data_location="zen"
 root_bin_path="/usr/bin"
@@ -31,11 +31,14 @@ case "$os_arch" in
     x86_64) echo "64-bit (Intel/AMD) architecture identified!" ;;
     aarch64|arm64)
 		echo "64-bit ARM architecture identified!"
-		official_package_location="https://github.com/zen-browser/desktop/releases/latest/download/zen.linux-aarch64.tar.xz" ;;
+		os_arch="aarch64" ;;
     *)
 		echo "Zen doesn't support this architecture: $os_arch"
 		exit 1 ;;
 esac
+
+# Set the official package download URL
+official_package_location="https://github.com/zen-browser/desktop/releases/latest/download/zen.linux-$os_arch.tar.xz"
 
 echo "Downloading the latest package"
 curl -L --progress-bar -o $tar_location $official_package_location

--- a/install-as-root.sh
+++ b/install-as-root.sh
@@ -17,6 +17,13 @@ desktop_in_local_applications="$root_application_path/$app_name.desktop"
 icon_path="$app_installation_directory/browser/chrome/icons/default/default128.png"
 executable_path=$app_installation_directory/zen
 
+# Check OS
+if [[ "$(uname)" != "Linux" ]]; then
+    echo "This script is only for Linux."
+    echo "Visit https://github.com/zen-browser/desktop#-installation to learn more about supported operating systems"
+    exit 1
+fi
+
 # Check if the script is being run as root
 if [ "$EUID" -ne 0 ]; then
     echo "This script requires superuser permissions. Please re-run as root."

--- a/install-as-root.sh
+++ b/install-as-root.sh
@@ -17,7 +17,7 @@ icon_path="$app_installation_directory/browser/chrome/icons/default/default128.p
 executable_path=$app_installation_directory/zen
 
 install() {
-  echo "We're installing Zen, just chill and wait for the installation to complete!\n"
+  echo -e "We're installing Zen, just chill and wait for the installation to complete!\n"
 
   # Set the official package download URL
   determinePackage "$@"

--- a/install-as-root.sh
+++ b/install-as-root.sh
@@ -134,7 +134,8 @@ remove() {
 }
 
 uninstall() {
-  read -p "WARN: This will remove Zen Browser from your system. Do you wish to proceed? [y/N]: " confirm
+  read -rn1 -p "WARN: This will remove Zen Browser from your system. Do you wish to proceed? [y/N]: " confirm
+  echo
   if [[ ! "$confirm" =~ ^[Yy]$ ]]; then
     echo "Nice save! We didn't remove Zen from your system."
     echo "Exiting..."
@@ -143,7 +144,8 @@ uninstall() {
   echo "Uninstalling Zen Browser..."
   remove
   echo "Keeping your profile data will let you continue where you left off if you reinstall Zen later."
-  read -p "Do you want to delete your Zen Profiles? This will remove all your bookmarks, history, and settings. [y/N]: " remove_profile
+  read -rn1 -p "Do you want to delete your Zen Profiles? This will remove all your bookmarks, history, and settings. [y/N]: " remove_profile
+  echo
   if [[ "$remove_profile" =~ ^[Yy]$ ]]; then
     echo "Removing Zen Profiles data..."
     rm -rf "$HOME/.zen"

--- a/install-as-root.sh
+++ b/install-as-root.sh
@@ -97,6 +97,21 @@ install() {
   exit 0
 }
 
+cleanup() {
+  echo -e "\n\nCleaning up...\n"
+  if [ -f "${tar_location:-}" ]; then
+    echo "Removing temporary tarball..."
+    rm -f "${tar_location:-}"
+  fi
+  if [ -d "$open_tar_application_data_location" ]; then
+    echo "Removing incomplete application directory..."
+    rm -rf "$open_tar_application_data_location"
+  fi
+  echo "If Zen Browser was partially installed, please run the script again to install/update/uninstall."
+  echo "Exiting gracefully..."
+  exit 1
+}
+
 determinePackage() {
   case "$os_arch" in
       x86_64) echo "64-bit (Intel/AMD) architecture identified!" ;;
@@ -155,6 +170,8 @@ uninstall() {
   echo "Zen Browser has been uninstalled."
   exit 0
 }
+
+trap cleanup SIGINT SIGTERM SIGHUP
 
 # Check OS
 if [[ "$(uname)" != "Linux" ]]; then

--- a/install-as-root.sh
+++ b/install-as-root.sh
@@ -149,7 +149,8 @@ remove() {
 }
 
 uninstall() {
-  read -rn1 -p "WARN: This will remove Zen Browser from your system. Do you wish to proceed? [y/N]: " confirm
+  echo -n "WARN: This will remove Zen Browser from your system. Do you wish to proceed? [y/N]: "
+  read -rn1 confirm < /dev/tty
   echo
   if [[ ! "$confirm" =~ ^[Yy]$ ]]; then
     echo "Nice save! We didn't remove Zen from your system."
@@ -159,7 +160,8 @@ uninstall() {
   echo "Uninstalling Zen Browser..."
   remove
   echo "Keeping your profile data will let you continue where you left off if you reinstall Zen later."
-  read -rn1 -p "Do you want to delete your Zen Profiles? This will remove all your bookmarks, history, and settings. [y/N]: " remove_profile
+  echo -n "Do you want to delete your Zen Profiles? This will remove all your bookmarks, history, and settings. [y/N]: "
+  read -rn1 remove_profile < /dev/tty
   echo
   if [[ "$remove_profile" =~ ^[Yy]$ ]]; then
     echo "Removing Zen Profiles data..."
@@ -194,7 +196,8 @@ echo "What would you like to do?"
 echo "1) Install/Update Zen Browser"
 echo "2) Uninstall Zen Browser"
 echo "3) Exit"
-read -rn1 -p "Enter your choice [1/2/3]: " choice
+echo -en "\nEnter your choice [1/2/3]: "
+read -rn1 choice < /dev/tty
 echo
 
 case $choice in

--- a/install-as-root.sh
+++ b/install-as-root.sh
@@ -8,7 +8,6 @@ literal_name_of_installation_directory="src"
 universal_path_for_installation_directory="/usr/local/$literal_name_of_installation_directory"
 app_installation_directory="$universal_path_for_installation_directory/zen"
 official_package_location="" # Placeholder for download URL, to be set later
-tar_location=$(mktemp /tmp/zen.XXXXXX.tar.xz)
 open_tar_application_data_location="zen"
 root_bin_path="/usr/bin"
 root_application_path="/usr/share/applications"
@@ -24,6 +23,7 @@ install() {
   determinePackage "$@"
 
   echo "Downloading the latest package"
+  tar_location=$(mktemp /tmp/zen.XXXXXX.tar.xz)
   curl -L --progress-bar -o $tar_location $official_package_location
 
   echo "Extracting Zen Browser..."

--- a/install-as-root.sh
+++ b/install-as-root.sh
@@ -12,7 +12,7 @@ open_tar_application_data_location="zen"
 root_bin_path="/usr/bin"
 root_application_path="/usr/share/applications"
 app_bin_in_root_bin="$root_bin_path/$app_name"
-desktop_in_local_applications="$root_application_path/$app_name.desktop"
+desktop_in_applications="$root_application_path/$app_name.desktop"
 icon_path="$app_installation_directory/browser/chrome/icons/default/default128.png"
 executable_path=$app_installation_directory/zen
 
@@ -63,32 +63,34 @@ install() {
   fi
 
 
-  touch $desktop_in_local_applications
-  echo "
-  [Desktop Entry]
-  Name=Zen Browser
-  Comment=Experience tranquillity while browsing the web without people tracking you!
-  Keywords=web;browser;internet
-  Exec=$executable_path %u
-  Icon=$icon_path
-  Terminal=false
-  StartupNotify=true
-  StartupWMClass=zen
-  NoDisplay=false
-  Type=Application
-  MimeType=text/html;text/xml;application/xhtml+xml;application/vnd.mozilla.xul+xml;text/mml;x-scheme-handler/http;x-scheme-handler/https;
-  Categories=Network;WebBrowser;
-  Actions=new-window;new-private-window;profile-manager-window;
-  [Desktop Action new-window]
-  Name=Open a New Window
-  Exec=$executable_path --new-window %u
-  [Desktop Action new-private-window]
-  Name=Open a New Private Window
-  Exec=$executable_path --private-window %u
-  [Desktop Action profile-manager-window]
-  Name=Open the Profile Manager
-  Exec=$executable_path --ProfileManager
-  " >> $desktop_in_local_applications
+  cat << EOF > $desktop_in_applications
+[Desktop Entry]
+Name=Zen Browser
+Comment=Experience tranquillity while browsing the web without people tracking you!
+Keywords=web;browser;internet
+Exec=$executable_path %u
+Icon=$icon_path
+Terminal=false
+StartupNotify=true
+StartupWMClass=zen
+NoDisplay=false
+Type=Application
+MimeType=text/html;text/xml;application/xhtml+xml;application/vnd.mozilla.xul+xml;text/mml;x-scheme-handler/http;x-scheme-handler/https;
+Categories=Network;WebBrowser;
+Actions=new-window;new-private-window;profile-manager-window;
+
+[Desktop Action new-window]
+Name=Open a New Window
+Exec=$executable_path --new-window %u
+
+[Desktop Action new-private-window]
+Name=Open a New Private Window
+Exec=$executable_path --private-window %u
+
+[Desktop Action profile-manager-window]
+Name=Open the Profile Manager
+Exec=$executable_path --ProfileManager
+EOF
 
   echo "Created desktop entry successfully"
   echo "Installation is successful"
@@ -142,9 +144,9 @@ remove() {
     rm -rf "$app_installation_directory"
   fi
 
-  if [ -f "$desktop_in_local_applications" ]; then
+  if [ -f "$desktop_in_applications" ]; then
     echo "Old desktop files are found, removing..."
-    rm "$desktop_in_local_applications"
+    rm "$desktop_in_applications"
   fi
 }
 


### PR DESCRIPTION
## The Problem
While the [1Password Integration Fix](https://docs.zen-browser.app/guides/1password) guide does help for some, like when installed through the aur, it fails for the native tarball installation or the AppImage. This is a problem for users running other distros than Arch.

## Solution
While I haven't discovered a solution for the AppImage, the native tarball install script installs Zen in the current user's `$HOME` directory. The [1Password Integration Fix](https://docs.zen-browser.app/guides/1password) guide would only work if Zen is installed at the root-level, and add `zen` (instead of `zen-bin`) to the `/etc/1password/custom_allowed_browsers` file.

## Changes
- [x] Added a seperate script that installs Zen to `/usr/local/src/zen`.
- [x] Added a script that automatically adds `zen` to `/etc/1password/custom_allowed_browsers` safely, with proper rollback if anything fails.
- [x] Backup 1Password config directory before the above script modifies it for safety.

## Credits
Thanks to [Kerren Ortlepp](https://kerrenortlepp.com/author/kerren/) for his article on [Running 1Password on Zen Browser](https://kerrenortlepp.com/running-1password-on-zen-browser).