### PR TITLE
Solved a issue of instalation related to symlink and enhanced update experience with zsync

### DIFF
--- a/appimage.sh
+++ b/appimage.sh
@@ -247,7 +247,11 @@ check_for_updates() {
         appimage_url="$ZEN_STABLE"
     fi
 
-    zsync_file="${HOME}/Downloads/$file_base.AppImage.zsync"
+    # Get the download directory using xdg-user-dir, using Downloads as default value
+	DOWNLOAD_DIR=$(xdg-user-dir DOWNLOAD || echo "${HOME}/Downloads")
+
+	# Set zsync file path
+	zsync_file="${DOWNLOAD_DIR}/${file_base}.AppImage.zsync"
 
     if check_installation_status "$file_base"; then
         log_info "Checking for updates..."

--- a/appimage.sh
+++ b/appimage.sh
@@ -162,11 +162,11 @@ process_appimage() {
     "${appimage_path}" --appimage-extract
 
     # Move .desktop file (from /squashfs-root only)
-    desktop_file=$(find squashfs-root -maxdepth 1 -name "*.desktop" | head -n 1)
+    desktop_file=$(find -L squashfs-root -maxdepth 1 -name "*.desktop" | head -n 1)
     mv "${desktop_file}" ~/.local/share/applications/${app_name}.desktop
 
     # Find PNG icon (from /squashfs-root only)
-    icon_file=$(find squashfs-root -maxdepth 1 -name "*.png" | head -n 1)
+    icon_file=$(find -L squashfs-root -maxdepth 1 -name "*.png" | head -n 1)
 
     # Resolve symlink if the icon is a symlink
     if [ -L "${icon_file}" ]; then


### PR DESCRIPTION
This PR is focused on solving the following issues:
- https://github.com/zen-browser/desktop/issues/6199
- https://github.com/zen-browser/desktop/issues/3830

It solves the problem of command `find` not working properly with symlinks and also adds a way to handle more downloads files using `xdg-user-dir`.