### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/pre-deploy.yml
+++ b/.github/workflows/pre-deploy.yml
@@ -1,4 +1,6 @@
 name: Pre-Deploy Updates Server
+permissions:
+  contents: write
 
 on:
   push:


### PR DESCRIPTION
Potential fix for [https://github.com/zen-browser/updates-server/security/code-scanning/1](https://github.com/zen-browser/updates-server/security/code-scanning/1)

To fix the problem, we need to add a `permissions:` block to the workflow, specifying the least permissions required by the jobs. The safest approach is to start with `contents: write` (because we are committing and pushing to the repository) and limit other permissions to `read` or leave them unset. Since this workflow pushes commits to the `deploy` branch, it requires write access for `contents`. Add the following block after the `name:` field (line 1), at the root level of the workflow. No additional dependencies or block-specific changes are required.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
