### PR TITLE
fix: forward command-line arguments in zen launcher script

### DIFF
--- a/install-twilight.sh
+++ b/install-twilight.sh
@@ -68,8 +68,10 @@ fi
 
 touch $app_bin_in_local_bin
 chmod u+x $app_bin_in_local_bin
-echo "#!/bin/bash
-$executable_path" >> $app_bin_in_local_bin
+cat > "$app_bin_in_local_bin" << EOF
+#!/bin/bash
+exec "$executable_path" "\$@"
+EOF
 
 echo "Created executable for your \$PATH if you ever need"
 

--- a/install.sh
+++ b/install.sh
@@ -89,8 +89,10 @@ fi
 
 touch $app_bin_in_local_bin
 chmod u+x $app_bin_in_local_bin
-echo "#!/bin/bash
-$executable_path" >> $app_bin_in_local_bin
+cat > "$app_bin_in_local_bin" << EOF
+#!/bin/bash
+exec "$executable_path" "\$@"
+EOF
 
 echo "Created executable for your \$PATH if you ever need"
 


### PR DESCRIPTION
Previously the generated launcher script ignored all command-line arguments. This change forwards "$@" so zen behaves correctly when invoked with flags or file paths.