### PR TITLE
feat: add --blank-window desktop action (v1.18.6+)

### DIFF
--- a/install-twilight.sh
+++ b/install-twilight.sh
@@ -96,10 +96,13 @@ NoDisplay=false
 Type=Application
 MimeType=text/html;text/xml;application/xhtml+xml;application/vnd.mozilla.xul+xml;text/mml;x-scheme-handler/http;x-scheme-handler/https;
 Categories=Network;WebBrowser;
-Actions=new-window;new-private-window;profile-manager-window;
+Actions=new-window;new-blank-window;new-private-window;profile-manager-window;
 [Desktop Action new-window]
 Name=Open a New Window
 Exec=$executable_path --new-window %u
+[Desktop Action new-blank-window]
+Name=Open a New Blank Window
+Exec=$executable_path --blank-window %u
 [Desktop Action new-private-window]
 Name=Open a New Private Window
 Exec=$executable_path --private-window %u

--- a/install.sh
+++ b/install.sh
@@ -117,10 +117,13 @@ NoDisplay=false
 Type=Application
 MimeType=text/html;text/xml;application/xhtml+xml;application/vnd.mozilla.xul+xml;text/mml;x-scheme-handler/http;x-scheme-handler/https;
 Categories=Network;WebBrowser;
-Actions=new-window;new-private-window;profile-manager-window;
+Actions=new-window;new-blank-window;new-private-window;profile-manager-window;
 [Desktop Action new-window]
 Name=Open a New Window
 Exec=$executable_path --new-window %u
+[Desktop Action new-blank-window]
+Name=Open a New Blank Window
+Exec=$executable_path --blank-window %u
 [Desktop Action new-private-window]
 Name=Open a New Private Window
 Exec=$executable_path --private-window %u


### PR DESCRIPTION
from https://github.com/zen-browser/desktop/releases/tag/1.18.6b: 
>  Added a '--blank-window' command line argument to open a blank window without pinned tabs, spaces, etc. 